### PR TITLE
Add Infiniband phyiscal network plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,16 @@ service, ironic inspector.
 Plugins
 =======
 
+Infiniband Physical Network
+---------------------------
+
+The ``ib_physnet`` plugin populates the ``physical_network`` field of ironic
+ports determined to be Infiniband ports. Ports with a ``client-id`` field
+in their ``extra`` attribute are determined to be IB ports.
+
+The plugin is configured via the option ``[port_physnet] ib_physnet``, which is
+the name of the physical network to apply.
+
 System Name Local Link Connection
 ---------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,6 @@ packages =
 
 [entry_points]
 ironic_inspector.hooks.processing =
+    ib_physnet = stackhpc_inspector_plugins.plugins.ib_physnet:IBPhysnetHook
     system_name_physnet = stackhpc_inspector_plugins.plugins.system_name_physnet:SystemNamePhysnetHook
     system_name_llc = stackhpc_inspector_plugins.plugins.system_name_llc:SystemNameLocalLinkConnectionHook

--- a/stackhpc_inspector_plugins/conf.py
+++ b/stackhpc_inspector_plugins/conf.py
@@ -19,6 +19,10 @@ from ironic_inspector.common.i18n import _
 
 
 PORT_PHYSNET_OPTS = [
+    cfg.StrOpt(
+        'ib_physnet',
+        help=_('Name of the physical network that the Infiniband network is '
+               'on')),
     cfg.ListOpt(
         'switch_sys_name_mapping',
         default=[],

--- a/stackhpc_inspector_plugins/plugins/ib_physnet.py
+++ b/stackhpc_inspector_plugins/plugins/ib_physnet.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2018 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ironic_inspector import utils
+from oslo_config import cfg
+
+from stackhpc_inspector_plugins.plugins import base_physnet
+
+LOG = utils.getProcessingLogger(__name__)
+
+CONF = cfg.CONF
+
+
+class IBPhysnetHook(base_physnet.BasePhysnetHook):
+    """Inspector hook to assign ports a physical network for IB interfaces.
+
+    This plugin sets the physical network for ports that are determined to be
+    Infiniband ports.  The physical network is given by the configuration
+    option [port_physnet] ib_physnet.
+    """
+
+    def get_physnet(self, port, iface_name, introspection_data):
+        """Return a physical network to apply to a port.
+
+        :param port: The ironic port to patch.
+        :param iface_name: Name of the interface.
+        :param introspection_data: Introspection data.
+        :returns: The physical network to set, or None.
+        """
+        proc_data = introspection_data['all_interfaces'][iface_name]
+        if proc_data.get('client_id'):
+            LOG.debug("Interface %s is an Infiniband port, physnet %s",
+                      iface_name, CONF.port_physnet.ib_physnet)
+            return CONF.port_physnet.ib_physnet

--- a/stackhpc_inspector_plugins/tests/unit/test_plugins_ib_physnet.py
+++ b/stackhpc_inspector_plugins/tests/unit/test_plugins_ib_physnet.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 StackHPC Ltd.
+# Copyright (c) 2018 StackHPC Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,10 +58,18 @@ class TestIBPhysnetHook(test_base.NodeTest):
         physnet = self.hook.get_physnet(port, 'em1', self.data)
         self.assertEqual(physnet, 'physnet1')
 
-    def test_expected_data_non_ib(self):
+    def test_expected_data_client_id_is_none(self):
         cfg.CONF.set_override('ib_physnet', 'physnet1',
                               group='port_physnet')
         self.data['all_interfaces']['em1']['client_id'] = None
+        port = self.node_info.ports().values()[0]
+        physnet = self.hook.get_physnet(port, 'em1', self.data)
+        self.assertIsNone(physnet)
+
+    def test_expected_data_no_client_id(self):
+        cfg.CONF.set_override('ib_physnet', 'physnet1',
+                              group='port_physnet')
+        del self.data['all_interfaces']['em1']['client_id']
         port = self.node_info.ports().values()[0]
         physnet = self.hook.get_physnet(port, 'em1', self.data)
         self.assertIsNone(physnet)

--- a/stackhpc_inspector_plugins/tests/unit/test_plugins_ib_physnet.py
+++ b/stackhpc_inspector_plugins/tests/unit/test_plugins_ib_physnet.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2017 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from ironic_inspector import node_cache
+from ironic_inspector.test import base as test_base
+from oslo_config import cfg
+
+from stackhpc_inspector_plugins.plugins import ib_physnet
+
+
+class TestIBPhysnetHook(test_base.NodeTest):
+
+    def setUp(self):
+        super(TestIBPhysnetHook, self).setUp()
+        self.hook = ib_physnet.IBPhysnetHook()
+        self.data = {
+            'inventory': {
+                'interfaces': [{
+                    'name': 'em1', 'mac_address': '11:11:11:11:11:11',
+                    'ipv4_address': '1.1.1.1',
+                }],
+                'cpu': 1,
+                'disks': 1,
+                'memory': 1
+            },
+            'all_interfaces': {
+                'em1': {
+                    'client_id': ('ff:00:00:00:00:00:02:00:00:02:c9:00:7c:fe:'
+                                  '90:03:00:3a:4b:0a'),
+                },
+            }
+        }
+
+        ports = [mock.Mock(spec=['address', 'uuid', 'physical_network'],
+                           address=a, physical_network='physnet1')
+                 for a in ('11:11:11:11:11:11',)]
+        self.node_info = node_cache.NodeInfo(uuid=self.uuid, started_at=0,
+                                             node=self.node, ports=ports)
+
+    def test_expected_data_ib(self):
+        cfg.CONF.set_override('ib_physnet', 'physnet1',
+                              group='port_physnet')
+        port = self.node_info.ports().values()[0]
+        physnet = self.hook.get_physnet(port, 'em1', self.data)
+        self.assertEqual(physnet, 'physnet1')
+
+    def test_expected_data_non_ib(self):
+        cfg.CONF.set_override('ib_physnet', 'physnet1',
+                              group='port_physnet')
+        self.data['all_interfaces']['em1']['client_id'] = None
+        port = self.node_info.ports().values()[0]
+        physnet = self.hook.get_physnet(port, 'em1', self.data)
+        self.assertIsNone(physnet)


### PR DESCRIPTION
The ib_physnet plugin populates the physical_network field of ironic
ports determined to be Infiniband ports. Ports with a 'client-id' field
in their 'extra' attribute are determined to be IB ports.

The plugin is configured via the option [port_physnet] ib_physnet, which
is the name of the physical network to apply.