### PR TITLE
Use py3 for tox by default, use train UC for python <= 3.5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,11 @@ envlist = py35,py27,pep8
 
 [testenv]
 usedevelop = True
-install_command = pip install -U -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt} {opts} {packages}
+install_command = pip install -U {opts} {packages}
+basepython = python3
 deps =
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+    -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands =
     coverage run --branch --include "stackhpc_inspector_plugins*" -m unittest discover stackhpc_inspector_plugins.tests.unit
@@ -22,9 +25,20 @@ commands =
     coverage report -m
 
 [testenv:pep8]
-basepython = python2.7
 commands =
     flake8 stackhpc_inspector_plugins
+
+[testenv:py27]
+deps =
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+
+[testenv:py35]
+deps =
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
 
 [flake8]
 max-complexity=15


### PR DESCRIPTION
Upstream OpenStack has dropped support for python 2, and even python
3.5. This means that master upper constraints no longer install on these
versions.