### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,13 @@ matrix:
     # Run python style checks.
     - python: 3.8
       env: TOXENV=pep8
-    # Run python3.8 units tests.
+    # Run python3.6 unit tests.
+    - python: 3.6
+      env: TOXENV=py36
+    # Run python3.7 unit tests.
+    - python: 3.7
+      env: TOXENV=py37
+    # Run python3.8 unit tests.
     - python: 3.8
       env: TOXENV=py38
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
 language: python
-python: "2.7"
 
 # Run jobs in containers.
 sudo: false
@@ -14,16 +13,20 @@ addons:
       - realpath
 
 # Create a build matrix for the different test jobs.
-env:
-  matrix:
-    # Run python style checks.
-    - TOX_ENV=pep8
+matrix:
+  include:
     # Run python2.7 unit tests.
-    - TOX_ENV=py27
+    - python: 2.7
+      env: TOXENV=py27
+    # Run python style checks.
+    - python: 3.8
+      env: TOXENV=pep8
+    # Run python3.8 units tests.
+    - python: 3.8
+      env: TOXENV=py38
 
 install:
   - pip install tox
 
 script:
-  # Run the tox environment.
-  - tox -e ${TOX_ENV}
+  - tox

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,8 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
+pyflakes>=2.2.0 # MIT
+python-ironicclient # Apache-2.0
 coverage!=4.4,>=4.0 # Apache-2.0
 flake8-import-order==0.11 # LGPLv3
 hacking<0.13,>=0.12.0 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py27,pep8
+envlist = py36,py37,py38,py27,pep8
 
 [testenv]
 usedevelop = True
@@ -36,6 +36,21 @@ deps =
     -r{toxinidir}/test-requirements.txt
 
 [testenv:py38]
+basepython = python3.8
+deps =
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+
+[testenv:py37]
+basepython = python3.7
+deps =
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/ussuri}
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+
+[testenv:py36]
+basepython = python3.6
 deps =
     -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist = py36,py37,py38,py27,pep8
 
-
 [testenv]
 usedevelop = True
 install_command = pip install -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,11 @@ envlist = py35,py27,pep8
 
 [testenv]
 usedevelop = True
-install_command = pip install -U -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt} {opts} {packages}
+install_command = pip install -U {opts} {packages}
+basepython = python3
 deps =
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+    -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands =
     coverage run --branch --include "stackhpc_inspector_plugins*" -m unittest discover stackhpc_inspector_plugins.tests.unit
@@ -22,9 +25,20 @@ commands =
     coverage report -m
 
 [testenv:pep8]
-basepython = python2.7
 commands =
     flake8 stackhpc_inspector_plugins
+
+[testenv:py27]
+deps =
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+
+[testenv:py35]
+deps =
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
 
 [flake8]
 max-complexity=15

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py35,py27,pep8
+envlist = py38,py27,pep8
 
 [testenv]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
-basepython = python3
+basepython = python3.8
 deps =
     -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
     -r{toxinidir}/requirements.txt
@@ -29,12 +29,13 @@ commands =
     flake8 stackhpc_inspector_plugins
 
 [testenv:py27]
+basepython = python2.7
 deps =
     -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 
-[testenv:py35]
+[testenv:py38]
 deps =
     -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = py36,py37,py38,py27,pep8
 
+
 [testenv]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
@@ -37,8 +38,9 @@ deps =
 
 [testenv:py38]
 basepython = python3.8
+# FIXME: Use ussuri release until victoria is released.
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/ussuri}
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 


### PR DESCRIPTION
Needed to specify pyflakes version early for:
```
    return self._retry_serial(self._styleguide.check_files, paths=paths)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/flake8/engine.py", line 172, in _retry_serial
    return func(*args, **kwargs)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pep8.py", line 1670, in check_files
    self.input_dir(path)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pep8.py", line 1706, in input_dir
    runner(os.path.join(root, filename))
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/flake8/engine.py", line 126, in input_file
    return fchecker.check_all(expected=expected, line_offset=line_offset)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pep8.py", line 1412, in check_all
    self.check_ast()
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pep8.py", line 1358, in check_ast
    checker = cls(tree, self.filename)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/flake8/_pyflakes.py", line 61, in __init__
    super(FlakesChecker, self).__init__(tree, filename,
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pyflakes/checker.py", line 294, in __init__
    self.handleChildren(tree)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pyflakes/checker.py", line 547, in handleChildren
    self.handleNode(node, tree)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pyflakes/checker.py", line 589, in handleNode
    handler(node)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pyflakes/checker.py", line 547, in handleChildren
    self.handleNode(node, tree)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pyflakes/checker.py", line 589, in handleNode
    handler(node)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pyflakes/checker.py", line 547, in handleChildren
    self.handleNode(node, tree)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pyflakes/checker.py", line 589, in handleNode
    handler(node)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pyflakes/checker.py", line 547, in handleChildren
    self.handleNode(node, tree)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pyflakes/checker.py", line 588, in handleNode
    handler = self.getNodeHandler(node.__class__)
  File "/home/will/code/stackhpc-inspector-plugins/.tox/pep8/lib/python3.8/site-packages/pyflakes/checker.py", line 458, in getNodeHandler
    self._nodeHandlers[node_class] = handler = getattr(self, nodeType)
AttributeError: 'FlakesChecker' object has no attribute 'CONSTANT'

```
See: https://github.com/PyCQA/pyflakes/issues/367

needed ironic client for:
```
ImportError: Failed to import test module: stackhpc_inspector_plugins.tests.unit.test_plugins_system_name_physnet
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.8/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/home/will/code/stackhpc-inspector-plugins/stackhpc_inspector_plugins/tests/unit/test_plugins_system_name_physnet.py", line 22, in <module>
    from stackhpc_inspector_plugins.plugins import system_name_physnet
  File "/home/will/code/stackhpc-inspector-plugins/stackhpc_inspector_plugins/plugins/system_name_physnet.py", line 20, in <module>
    from stackhpc_inspector_plugins.plugins import base_physnet
  File "/home/will/code/stackhpc-inspector-plugins/stackhpc_inspector_plugins/plugins/base_physnet.py", line 21, in <module>
    from ironicclient import exc as client_exc
ModuleNotFoundError: No module named 'ironicclient'

```